### PR TITLE
Version Lock 'js' Dependency to '0.6.5'

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: braze_plugin_web
 description: Unofficial Braze Plugin for Flutter for Web. It is mostly a Flutter Web Plugin acting as a wrapper around the official Braze Web SDK.
 repository: https://github.com/OncoHealth/braze_plugin_web
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.17.6 <4.0.0"
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   # JavaScript Interop
-  js: ^0.6.7
+  js: 0.6.5
 
 flutter:
   plugin:


### PR DESCRIPTION
This is done to maintain compatibility with older versions of Flutter (<=3.7.3)